### PR TITLE
Remove compromised polyfill.io dependency

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,6 @@ extra_javascript:
   - javascripts/svg.js
   - javascripts/onload.js
 #  - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 nav:


### PR DESCRIPTION
## What

Removes the `https://polyfill.io/v3/polyfill.min.js?features=es6` entry from `extra_javascript` in `mkdocs.yml`.

## Why

`polyfill.io` was loaded at runtime in the `<head>` of every generated docs page as a dependency for MathJax. In **June 2024** the domain changed ownership and began **serving malicious code** — a supply-chain attack (redirects to scam/phishing pages). Cloudflare/Fastly and the original author publicly recommended removing it.

Because the script is fetched from a third-party CDN at runtime, every visitor executes whatever that domain currently returns — content we don't control.

## Impact

None expected. ES6 polyfills are no longer needed — all modern browsers support ES6 natively, and MathJax 3 (`tex-mml-chtml.js`) works without the polyfill. The only other repo reference (`docs/javascripts/svg.js:413`) is just a code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)