### PR TITLE
MILAB-6496: Document FEATURE/FB tag pattern group names

### DIFF
--- a/docs/mixcr/reference/ref-tag-pattern.md
+++ b/docs/mixcr/reference/ref-tag-pattern.md
@@ -146,6 +146,7 @@ examples:
 
 Some rules apply to group names:
 - Everything that starts with `CELL` is treated as a cell barcode
+- Everything that starts with `FEATURE` or `FB` is treated as a feature (antigen) barcode
 - Everything that starts with `UMI` or `MI` (ex. `MIG`) is used as a molecular barcode
 - Everything that starts with `S` is a sample barcode.
 - `R1`, `R2` etc. groups define the payload read sequence.


### PR DESCRIPTION
Adds the `Feature` tag type to the capture-group naming rules in the tag-pattern reference (`ref-tag-pattern.md`): group names starting with `FEATURE` or `FB` are now recognized as feature (antigen) barcodes.

Companion to the mitool change milaboratory/mitool#86 (which adds the `Feature` tag type). Accurate once that change ships.

Ticket: MILAB-6496.